### PR TITLE
script install erpnext - inserito workspace file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.code-workspace
+#*.code-workspace
 
 # Environment Variables
 .env
@@ -6,8 +6,10 @@
 # mounted volume
 sites
 
-development
-!development/README.md
+#development
+#!development/README.md
+development/.vscode
+frappe-bench
 deploy_key
 deploy_key.pub
 

--- a/development/install_erpnext.sh
+++ b/development/install_erpnext.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+rm -R frappe-bench
+
+bench init --skip-redis-config-generation --frappe-path https://github.com/GraficheAquilane2021/frappe --frappe-branch version-12 frappe-bench
+cd frappe-bench
+
+bench set-mariadb-host mariadb
+bench set-redis-cache-host redis-cache:6379
+bench set-redis-queue-host redis-queue:6379
+bench set-redis-socketio-host redis-socketio:6379
+
+bench new-site erpnext.localhost --mariadb-root-password 123 --admin-password admin --no-mariadb-socket
+
+bench --site erpnext.localhost set-config developer_mode 1
+bench --site erpnext.localhost clear-cache
+
+bench get-app --branch version-12 erpnext https://github.com/GraficheAquilane2021/erpnext.git
+bench --site erpnext.localhost install-app erpnext

--- a/development/workspace.code-workspace
+++ b/development/workspace.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "../development/frappe-bench/apps/erpnext"
+		},
+		{
+			"path": "../development/frappe-bench/apps/frappe"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
ora è possibile installare erpnext in dev con un semplice ./install_erpnext.
All'avvio del docker vscode ti chiede se vuoi aprire il workspace